### PR TITLE
fixed shootout start/end

### DIFF
--- a/o8g/Scripts/customscripts.py
+++ b/o8g/Scripts/customscripts.py
@@ -1026,11 +1026,15 @@ def CustomScript(card, action = 'PLAY'): # Scripts that are complex and fairly u
            grit +=5
         if grit >= 11:
            dudes = findTarget("AutoTargeted-atDude-isParticipating-isBooted-targetMine")
-           notify(":> {} has to be unbooted to use his ability".format(dudes))
+           
+           
            dudes.remove(card)
            if not len(dudes): return
-           chosenCard = askCard(dudes,"Choose which dude to unboot")
-           boot(dudes[0], forced = 'unboot')
+           if len(dudes) == 1:
+                chosenCard = dudes[0]
+           else:
+                chosenCard = askCard(dudes,"Choose which dude to unboot")
+           boot(chosenCard, forced = 'unboot')
    elif card.name == 'Zeb Whateley-Dupont':
         if OutfitCard.Outfit == 'The Fourth Ring':
             TokensX('Put1High Noon:Stud', '', card)
@@ -1210,7 +1214,7 @@ def CustomScript(card, action = 'PLAY'): # Scripts that are complex and fairly u
         dude.markers[mdict['PermControlPlus']] += 1
    elif card.name == "Father Tolarios":
         if len(me.hand):
-            cardChoice = askCard([c for c in me.hand])
+            cardChoice = askCard([c for c in me.hand], "Chose a card you want to discard")
         else:
             notify("You need to discard a card to use this ability")
             return
@@ -1501,6 +1505,8 @@ def CookinTroubleEnd(card,cardChoice):
 def NathanShaneStart(card):
    mute()
    bullets = compileCardStat(card, stat = 'Bullets')
+   if bullets > len(me.hand):
+        bullets = len(me.hand)
    if not len(me.hand): notify(":::INFO::: {}'s play hand is empty. Nathan has nothing to snipe".format(me))
    elif not bullets: notify(":::INFO::: {} has currently 0 bullets and no capacity to snipe anything".format(card))
    else:

--- a/o8g/definition.xml
+++ b/o8g/definition.xml
@@ -4,7 +4,7 @@
       name="Doomtown-Reloaded" 
       id="b440d120-025a-4fbe-9f8d-3873acacb37b" 
       octgnVersion="3.1.0.0"
-      version="1.18.0.2" 
+      version="1.18.0.3" 
       markersize="16"
       tags="western deadlands poker maneuvering multiplayer"
       description="Doomtown Rides again! The award winning game of poker gunfights and spatial maneuvering is back.
@@ -91,7 +91,7 @@
 			<groupaction menu="Jump to Upkeep Phase." default="False" shortcut="F2" execute="goToUpkeep" />
 			<groupaction menu="Jump to High Noon Phase." default="False" shortcut="F3" execute="goToHighNoon" />
 			<groupaction menu="Jump to Sundown Phase." default="False" shortcut="F4" execute="goToNightfall" />
-			<groupaction menu="Start/End a Shootout Phase." default="False" shortcut="F10" execute="goToShootout" />
+			<groupaction menu="Start/End a Shootout Phase." default="False" shortcut="Ctrl+J" execute="goToShootout" />
 		</groupactions>
 		<groupaction menu="Announce Pass." default="False" shortcut="Ctrl+Space" execute="Pass" />
 		<groupaction menu="Announce Ready." default="False" shortcut="Ctrl+R" execute="Ready" />


### PR DESCRIPTION
Due to changes to F10 being reserved key in octgn I added ctrl+j as a replacement for F10. Additionally, Nathan and Rosenbaum's Golem scripts has been fixed