### PR TITLE
Fixing Jade Kings OCTGN ID (and ticking up game version)

### DIFF
--- a/o8g/Sets/Too Tough to Die/set.xml
+++ b/o8g/Sets/Too Tough to Die/set.xml
@@ -857,7 +857,7 @@
 		         <property name="Text" value="Noon: Boot your stud at a deed you control but do not own. Boot that deed to gain ghost rock equal to your stud’s bullets, to a maximum of 3. You may ace this card to give that deed a permanent +1 control point and that dude a permanent +1 influence." />
 		         <property name="Instructions" value="" />
       </card>
-		<card id="ae22bba2-cf1e-4038-b7bb-1d3429c10053" name="Jade King Stance">
+		<card id="ae22bba2-cf1e-4038-b7bb-1d3429c10054" name="Jade King Stance">
 		         <property name="Rank" value="3" />
 		         <property name="Suit" value="Clubs" />
 		         <property name="Type" value="Action" />

--- a/o8g/definition.xml
+++ b/o8g/definition.xml
@@ -4,7 +4,7 @@
       name="Doomtown-Reloaded" 
       id="b440d120-025a-4fbe-9f8d-3873acacb37b" 
       octgnVersion="3.2.75.0"
-      version="1.18.0.5" 
+      version="1.18.0.6" 
       markersize="16"
       tags="western deadlands poker maneuvering multiplayer"
       description="Doomtown Rides again! The award winning game of poker gunfights and spatial maneuvering is back.


### PR DESCRIPTION
Simple fix of an octgn ID - it has already been updated in dtdb.

No rush, and thanks for keeping up with this @db0 !